### PR TITLE
Fix card styling and remove seen count from detail view

### DIFF
--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -131,8 +131,8 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                   <div className="absolute bottom-0 left-0 right-0 h-28">
                     <div className="absolute bottom-6 left-0 right-0 mx-[-2px]">
                       <div className="bg-white/70 backdrop-blur-[17px] border-2 border-gray-800 h-[90px] relative">
-                        <div className="absolute inset-0 flex flex-col items-center justify-center text-center px-4">
-                          <h2 className="text-2xl font-normal uppercase text-gray-800 leading-tight mb-1 font-rubik-one">
+                        <div className="absolute inset-0 flex flex-col items-center justify-center text-center p-4">
+                          <h2 className="text-xl font-light uppercase text-gray-800 leading-tight mb-1 font-rubik-one">
                             {bird.name}
                           </h2>
                           <p className="text-lg italic text-gray-800 font-normal">

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -102,7 +102,9 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                   <img
                     src={bird.imageUrl}
                     alt={bird.name}
-                    className="w-full h-full object-cover"
+                    className={`w-full h-full object-cover transition-all duration-300 ${
+                      !isCollected ? 'grayscale' : ''
+                    }`}
                   />
 
                   {/* Rarity Badge */}

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -82,7 +82,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
             {/* Main Bird Card */}
             <div
               {...cardProps}
-              className={`bg-white rounded-2xl overflow-hidden mb-20 gpu-accelerated transition-shadow duration-150 relative ${
+              className={`bg-white rounded-[30px] p-2 mb-20 gpu-accelerated transition-shadow duration-150 relative overflow-hidden ${
                 isHovered
                   ? 'shadow-[0_25px_60px_rgba(0,0,0,0.4),0_0_30px_rgba(255,255,255,0.15),inset_0_2px_0_rgba(255,255,255,0.7)]'
                   : 'shadow-lg'
@@ -90,13 +90,13 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
             >
               {/* Holographic Glare Effect */}
               <div
-                className="absolute inset-0 rounded-2xl pointer-events-none z-10"
+                className="absolute inset-0 rounded-[30px] pointer-events-none z-20"
                 {...glareProps}
               />
 
               {/* Holographic Shine Effect */}
               <div
-                className="absolute inset-0 rounded-2xl pointer-events-none z-10"
+                className="absolute inset-0 rounded-[30px] pointer-events-none z-20"
                 {...shineProps}
               />
               <div className="relative rounded-[27px] border-2 border-gray-800 overflow-hidden">

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -121,7 +121,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
 
                   {/* Name Box - positioned at bottom of image */}
                   <div className="absolute bottom-0 left-0 right-0">
-                    <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px] mb-1">
+                    <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px]">
                       <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                         <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                           {bird.name}

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -123,7 +123,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                   <div className="absolute bottom-0 left-0 right-0">
                     <div className="bg-white/70 backdrop-blur-sm border-t border-black mx-[-1px] rounded-b-xl">
                       <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
-                        <h3 className="text-[#2C2C2C] font-rubik font-medium text-sm uppercase leading-tight">
+                        <h3 className="text-[#2C2C2C] font-rubik font-bold text-sm uppercase leading-tight">
                           {bird.name}
                         </h3>
                         <p className="text-[#2C2C2C]/50 font-rubik text-xs italic mt-1">

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -99,46 +99,40 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                 className="absolute inset-0 rounded-2xl pointer-events-none z-10"
                 {...shineProps}
               />
-              <div className="relative rounded-[27px] border-2 border-gray-800 overflow-hidden">
-                {/* Subtle sheen overlay */}
-                <div
-                  className={`absolute inset-0 rounded-[27px] pointer-events-none transition-opacity duration-300 z-10 ${
-                    isHovered ? 'opacity-20' : 'opacity-0'
-                  }`}
-                  style={{
-                    background: 'linear-gradient(45deg, transparent 30%, rgba(255,255,255,0.3) 50%, transparent 70%)'
-                  }}
-                />
+              {/* Card Content */}
+              <div className="relative p-1 z-0">
                 {/* Bird Image */}
-                <div className="aspect-[35/52] relative">
+                <div className="relative aspect-[35/52] rounded-xl overflow-hidden border border-black">
                   <img
                     src={bird.imageUrl}
                     alt={bird.name}
                     className="w-full h-full object-cover"
                   />
-                  
+
                   {/* Rarity Badge */}
-                  <div className="absolute top-4 right-4 bg-white/70 backdrop-blur-sm rounded-full border-2 border-gray-800 px-3 py-1 flex items-center gap-2">
-                    <svg className="w-3 h-3 fill-gray-800" viewBox="0 0 12 11">
-                      <path d="M10.7939 0.100586C11.2926 -0.0475992 11.7913 0.264859 11.6553 0.643555C11.5419 1.02219 11.3608 1.4996 11.0889 2.02637C10.5675 3.06366 8.69602 4.28219 7.22266 4.5127H9.45703C9.07169 4.95725 8.61802 5.41859 8.09668 5.84668C7.48473 6.34058 6.87269 6.81791 6.26074 7.22949L4.88281 7.54297L5.42188 7.77246C3.56317 8.94148 2.54294 9.07385 1.79492 8.79395C3.15495 6.99926 3.76219 6.18316 6.10254 4.99316C3.98679 6.0128 2.86091 6.93203 1.43359 8.61035C1.53939 8.68316 1.64564 8.7303 1.77246 8.77637C1.13778 9.58315 0.820725 10.1108 0.775391 10.1602C0.707361 10.2589 0.548078 10.3082 0.412109 10.2588C0.276339 10.2093 0.231066 10.0938 0.276367 9.99512V9.97852C0.321857 9.92883 0.659696 9.45411 1.40234 8.60352C1.3899 8.5972 1.37671 8.58912 1.36426 8.58008C0.253786 7.872 1.04797 5.92852 4.37988 3.21191L4.88281 3.97266C5.1548 3.26479 5.49058 2.89946 6.10254 2.32324C6.71441 1.76358 7.46196 1.28601 8.3457 0.923828C8.36833 0.923828 8.39143 0.907282 8.41406 0.907227C8.43659 1.65878 8.62415 1.92863 8.62695 1.93262L9.81934 0.396484C10.1819 0.281275 10.4994 0.182891 10.7939 0.100586Z" />
+                  <div className="absolute top-2 right-2 w-6 h-6 bg-[#F3F3F3] border border-[#2C2C2C] rounded-full flex items-center justify-center">
+                    <svg
+                      width="12"
+                      height="10"
+                      viewBox="0 0 8 15"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="w-3 h-2.5 fill-[#2C2C2C] transform rotate-[-23.972deg]"
+                    >
+                      <path d="M6.80255 0.39989C7.2046 0.0565747 7.79657 0.141577 7.82664 0.549448C7.87776 0.948024 7.90655 1.46684 7.87151 2.06849C7.81534 3.24752 6.58006 5.15219 5.30671 5.97482L7.38227 5.05195C7.20793 5.62405 6.9769 6.23934 6.66944 6.85232C6.30497 7.5639 5.934 8.26036 5.53553 8.89549L4.38439 9.75574L4.9811 9.74692C3.73732 11.6006 2.84391 12.1447 2.03342 12.1936C2.55555 9.96461 2.78201 8.95583 4.46463 6.88361C2.91991 8.70524 2.25359 10.0244 1.62073 12.1741C1.74943 12.1982 1.86808 12.1976 2.00526 12.188C1.74894 13.1996 1.67207 13.8202 1.65036 13.8848C1.62797 14.0046 1.50066 14.1164 1.35393 14.1267C1.20719 14.137 1.11769 14.0477 1.119 13.9372L1.11225 13.9221C1.13426 13.8556 1.25174 13.2748 1.5899 12.1792C1.57575 12.1786 1.56048 12.1757 1.54518 12.1724C0.220929 11.9735 0.155025 9.84108 2.12819 5.94103L2.91001 6.43985C2.87025 5.66976 3.03111 5.19109 3.36163 4.40293C3.69894 3.63018 4.1965 2.87754 4.86803 2.17597C4.88904 2.16658 4.90361 2.14198 4.92464 2.13263C5.25854 2.82686 5.54558 2.99795 5.54558 2.99795L6.01943 1.07834C6.30873 0.821472 6.56282 0.598078 6.80255 0.39989Z" fill="#2C2C2C"/>
                     </svg>
-                    <span className="text-xs font-bold uppercase tracking-wider text-gray-800">
-                      {bird.rarity}
-                    </span>
                   </div>
 
-                  {/* Name Box Overlay */}
-                  <div className="absolute bottom-0 left-0 right-0 h-28">
-                    <div className="absolute bottom-0 left-0 right-0 mx-[-2px]">
-                      <div className="bg-white/70 backdrop-blur-[17px] border-2 border-gray-800 h-[90px] relative">
-                        <div className="absolute inset-0 flex flex-col items-center justify-center text-center p-4">
-                          <h2 className="text-xl font-light uppercase text-gray-800 leading-tight mb-1 font-rubik-one">
-                            {bird.name}
-                          </h2>
-                          <p className="text-lg italic text-gray-800 font-normal">
-                            {bird.ability}
-                          </p>
-                        </div>
+                  {/* Name Box - positioned at bottom of image */}
+                  <div className="absolute bottom-0 left-0 right-0">
+                    <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px] mb-1">
+                      <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
+                        <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
+                          {bird.name}
+                        </h3>
+                        <p className="text-[#2C2C2C]/50 font-rubik text-xs italic mt-1">
+                          {bird.ability}
+                        </p>
                       </div>
                     </div>
                   </div>

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -121,7 +121,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
 
                   {/* Name Box - positioned at bottom of image */}
                   <div className="absolute bottom-0 left-0 right-0">
-                    <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px] rounded-b-xl">
+                    <div className="bg-white/70 backdrop-blur-sm border-t border-black mx-[-1px] rounded-b-xl">
                       <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                         <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                           {bird.name}

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -171,10 +171,12 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                   <div className="flex justify-between gap-4">
                     {bird.additionalImages.slice(0, 2).map((imageUrl, index) => (
                       <div key={index} className="w-[48%] aspect-square rounded-xl overflow-hidden relative">
-                        <img 
-                          src={imageUrl} 
+                        <img
+                          src={imageUrl}
                           alt={`${bird.name} - ${index === 0 ? 'Male' : 'Female'}`}
-                          className="w-full h-full object-cover"
+                          className={`w-full h-full object-cover transition-all duration-300 ${
+                            !isCollected ? 'grayscale' : ''
+                          }`}
                         />
                         {/* Gradient Overlay */}
                         <div 

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -114,7 +114,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                   <img
                     src={bird.imageUrl}
                     alt={bird.name}
-                    className="w-full h-full object-cover border-2 border-solid overflow-hidden"
+                    className="w-full h-full object-cover border-2 border-gray-800 overflow-hidden"
                   />
                   
                   {/* Rarity Badge */}

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -111,10 +111,10 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                 />
                 {/* Bird Image */}
                 <div className="aspect-[35/52] relative">
-                  <img 
-                    src={bird.imageUrl} 
+                  <img
+                    src={bird.imageUrl}
                     alt={bird.name}
-                    className="w-full h-full object-cover"
+                    className="w-full h-full object-cover border-2 border-solid overflow-hidden"
                   />
                   
                   {/* Rarity Badge */}

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -96,7 +96,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
 
               {/* Holographic Shine Effect */}
               <div
-                className="absolute inset-0 rounded-[30px] pointer-events-none z-20"
+                className="absolute inset-0 rounded-2xl pointer-events-none z-10"
                 {...shineProps}
               />
               <div className="relative rounded-[27px] border-2 border-gray-800 overflow-hidden">

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -99,7 +99,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                 className="absolute inset-0 rounded-[30px] pointer-events-none z-20"
                 {...shineProps}
               />
-              <div className="relative rounded-[27px] border-2 border-white overflow-hidden">
+              <div className="relative rounded-[27px] border-2 border-gray-800 overflow-hidden">
                 {/* Subtle sheen overlay */}
                 <div
                   className={`absolute inset-0 rounded-[27px] pointer-events-none transition-opacity duration-300 z-10 ${
@@ -114,7 +114,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                   <img
                     src={bird.imageUrl}
                     alt={bird.name}
-                    className="w-full h-full object-cover border-2 border-gray-800 overflow-hidden"
+                    className="w-full h-full object-cover"
                   />
                   
                   {/* Rarity Badge */}
@@ -129,7 +129,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
 
                   {/* Name Box Overlay */}
                   <div className="absolute bottom-0 left-0 right-0 h-28">
-                    <div className="absolute bottom-6 left-0 right-0 mx-[-2px]">
+                    <div className="absolute bottom-0 left-0 right-0 mx-[-2px]">
                       <div className="bg-white/70 backdrop-blur-[17px] border-2 border-gray-800 h-[90px] relative">
                         <div className="absolute inset-0 flex flex-col items-center justify-center text-center p-4">
                           <h2 className="text-xl font-light uppercase text-gray-800 leading-tight mb-1 font-rubik-one">

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -26,10 +26,6 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
 
   const isCollected = bird ? isInCollection(bird.id) : false;
 
-  // Simulate seen count - in real app this would come from data
-  const seenCount = Math.floor(Math.random() * 20) + 1;
-
-
 
   const handleCollectionToggle = () => {
     if (!bird) return;
@@ -140,12 +136,6 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
               </div>
             </div>
 
-            {/* Seen Count */}
-            <div className="mb-6 -mt-16">
-              <span className="text-xs font-bold uppercase tracking-wider text-gray-800">
-                Seen {seenCount} times
-              </span>
-            </div>
 
             {/* Content Sections */}
             <div className="space-y-10">

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -121,7 +121,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
 
                   {/* Name Box - positioned at bottom of image */}
                   <div className="absolute bottom-0 left-0 right-0">
-                    <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px]">
+                    <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px] rounded-b-xl">
                       <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                         <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                           {bird.name}

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -90,7 +90,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
             >
               {/* Holographic Glare Effect */}
               <div
-                className="absolute inset-0 rounded-[31px] pointer-events-none z-20"
+                className="absolute inset-0 rounded-[30px] pointer-events-none z-20"
                 {...glareProps}
               />
 

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -90,7 +90,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
             >
               {/* Holographic Glare Effect */}
               <div
-                className="absolute inset-0 rounded-[30px] pointer-events-none z-20"
+                className="absolute inset-0 rounded-2xl pointer-events-none z-10"
                 {...glareProps}
               />
 

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -82,7 +82,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
             {/* Main Bird Card */}
             <div
               {...cardProps}
-              className={`bg-white rounded-[31px] p-2 mb-20 gpu-accelerated transition-shadow duration-150 relative ${
+              className={`bg-white rounded-[30px] p-2 mb-20 gpu-accelerated transition-shadow duration-150 relative overflow-hidden ${
                 isHovered
                   ? 'shadow-[0_25px_60px_rgba(0,0,0,0.4),0_0_30px_rgba(255,255,255,0.15),inset_0_2px_0_rgba(255,255,255,0.7)]'
                   : 'shadow-lg'

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -82,7 +82,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
             {/* Main Bird Card */}
             <div
               {...cardProps}
-              className={`bg-white rounded-[30px] p-2 mb-20 gpu-accelerated transition-shadow duration-150 relative overflow-hidden ${
+              className={`bg-white rounded-2xl overflow-hidden mb-20 gpu-accelerated transition-shadow duration-150 relative ${
                 isHovered
                   ? 'shadow-[0_25px_60px_rgba(0,0,0,0.4),0_0_30px_rgba(255,255,255,0.15),inset_0_2px_0_rgba(255,255,255,0.7)]'
                   : 'shadow-lg'

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -123,7 +123,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
                   <div className="absolute bottom-0 left-0 right-0">
                     <div className="bg-white/70 backdrop-blur-sm border-t border-black mx-[-1px] rounded-b-xl">
                       <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
-                        <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
+                        <h3 className="text-[#2C2C2C] font-rubik font-medium text-sm uppercase leading-tight">
                           {bird.name}
                         </h3>
                         <p className="text-[#2C2C2C]/50 font-rubik text-xs italic mt-1">

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -82,7 +82,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
             {/* Main Bird Card */}
             <div
               {...cardProps}
-              className={`bg-white rounded-[30px] p-2 mb-20 gpu-accelerated transition-shadow duration-150 relative overflow-hidden ${
+              className={`bg-white rounded-2xl overflow-hidden mb-20 gpu-accelerated transition-shadow duration-150 relative ${
                 isHovered
                   ? 'shadow-[0_25px_60px_rgba(0,0,0,0.4),0_0_30px_rgba(255,255,255,0.15),inset_0_2px_0_rgba(255,255,255,0.7)]'
                   : 'shadow-lg'
@@ -90,13 +90,13 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
             >
               {/* Holographic Glare Effect */}
               <div
-                className="absolute inset-0 rounded-[30px] pointer-events-none z-20"
+                className="absolute inset-0 rounded-2xl pointer-events-none z-10"
                 {...glareProps}
               />
 
               {/* Holographic Shine Effect */}
               <div
-                className="absolute inset-0 rounded-[30px] pointer-events-none z-20"
+                className="absolute inset-0 rounded-2xl pointer-events-none z-10"
                 {...shineProps}
               />
               <div className="relative rounded-[27px] border-2 border-gray-800 overflow-hidden">

--- a/client/components/BirdDetailModal.tsx
+++ b/client/components/BirdDetailModal.tsx
@@ -96,7 +96,7 @@ export function BirdDetailModal({ bird, open, onOpenChange }: BirdDetailModalPro
 
               {/* Holographic Shine Effect */}
               <div
-                className="absolute inset-0 rounded-[31px] pointer-events-none z-20"
+                className="absolute inset-0 rounded-[30px] pointer-events-none z-20"
                 {...shineProps}
               />
               <div className="relative rounded-[27px] border-2 border-white overflow-hidden">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -175,6 +175,18 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
             </div>
           )}
         </div>
+
+        {/* Name Box - moved to bottom of card */}
+        <div className="bg-white border border-black mx-[-1px] mb-1">
+          <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
+            <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
+              {bird.name}
+            </h3>
+            <p className="text-[#2C2C2C]/50 font-rubik text-xs italic mt-1">
+              {bird.ability}
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -177,7 +177,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
 
           {/* Name Box - positioned at bottom of image */}
           <div className="absolute bottom-0 left-0 right-0">
-            <div className="bg-white/70 border border-black mx-[-1px] mb-[-2px]" style={{ backdropFilter: 'blur(12px)', borderBottomLeftRadius: '15px', borderBottomRightRadius: '12px', borderWidth: '1.5px' }}>
+            <div className="bg-white/70 border-t border-black mx-[-1px] mb-[-2px]" style={{ backdropFilter: 'blur(12px)', borderBottomLeftRadius: '15px', borderBottomRightRadius: '12px', borderTopWidth: '1.5px' }}>
               <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                 <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                   {bird.name}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -177,7 +177,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
 
           {/* Name Box - positioned at bottom of image */}
           <div className="absolute bottom-0 left-0 right-0">
-            <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px]">
+            <div className="bg-white/70 backdrop-blur-md border border-black mx-[-1px] mb-[-2px]">
               <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                 <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                   {bird.name}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -144,7 +144,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
       {/* Card Content */}
       <div className="relative p-1 z-0">
         {/* Bird Image */}
-        <div className="relative aspect-[154/253] rounded-xl overflow-hidden border border-white">
+        <div className="relative aspect-[154/253] rounded-xl overflow-hidden border border-black">
           <img 
             src={bird.imageUrl} 
             alt={bird.name}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -144,7 +144,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
       {/* Card Content */}
       <div className="relative p-1 z-0">
         {/* Bird Image */}
-        <div className="relative aspect-[154/253] rounded-xl overflow-hidden border-2 border-black">
+        <div className="relative aspect-[154/253] rounded-xl overflow-hidden border border-black">
           <img 
             src={bird.imageUrl} 
             alt={bird.name}
@@ -177,7 +177,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
 
           {/* Name Box - positioned at bottom of image */}
           <div className="absolute bottom-0 left-0 right-0">
-            <div className="bg-white border border-black mx-[-1px] mb-1">
+            <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px] mb-1">
               <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                 <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                   {bird.name}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -66,6 +66,54 @@ function LocationPackContent() {
     return periodGreetings[Math.floor(Math.random() * periodGreetings.length)];
   };
 
+  // Function to get dynamic circles colors based on time period
+  const getCircleColors = (period: string) => {
+    switch (period) {
+      case 'early-morning':
+        return {
+          circle1: '#FFB6C1', // Light pink
+          circle2: '#FFD700', // Gold
+          circle3: '#FFA07A'  // Light salmon
+        };
+      case 'morning':
+        return {
+          circle1: '#87CEEB', // Sky blue
+          circle2: '#F0E68C', // Khaki
+          circle3: '#98FB98'  // Pale green
+        };
+      case 'noon':
+        return {
+          circle1: '#00BFFF', // Deep sky blue
+          circle2: '#87CEFA', // Light sky blue
+          circle3: '#B0E0E6'  // Powder blue
+        };
+      case 'afternoon':
+        return {
+          circle1: '#FFD700', // Gold
+          circle2: '#FF8C00', // Dark orange
+          circle3: '#FFA500'  // Orange
+        };
+      case 'evening':
+        return {
+          circle1: '#FF6347', // Tomato
+          circle2: '#DA70D6', // Orchid
+          circle3: '#8A2BE2'  // Blue violet
+        };
+      case 'night':
+        return {
+          circle1: '#2F4F4F', // Dark slate gray
+          circle2: '#483D8B', // Dark slate blue
+          circle3: '#191970'  // Midnight blue
+        };
+      default:
+        return {
+          circle1: '#87CEEB',
+          circle2: '#F0E68C',
+          circle3: '#98FB98'
+        };
+    }
+  };
+
   // Function to get background gradient for each time period
   const getBackgroundGradient = (period: string) => {
     switch (period) {
@@ -169,6 +217,61 @@ function LocationPackContent() {
       >
       </div>
 
+      {/* Dynamic Background Circles */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <svg
+          className="absolute inset-0 w-full h-full transition-all duration-1000 ease-in-out"
+          viewBox="0 0 393 887"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          preserveAspectRatio="xMidYMid slice"
+        >
+          <defs>
+            <filter id="blur1" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur stdDeviation="100" />
+            </filter>
+            <filter id="blur2" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur stdDeviation="80" />
+            </filter>
+            <filter id="blur3" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur stdDeviation="120" />
+            </filter>
+          </defs>
+
+          {/* Large pink/primary circle */}
+          <circle
+            cx="12%"
+            cy="46%"
+            r="35%"
+            fill={getCircleColors(timeOfDay).circle1}
+            filter="url(#blur1)"
+            opacity="0.6"
+            className="transition-all duration-1000 ease-in-out"
+          />
+
+          {/* Medium cyan/secondary circle */}
+          <circle
+            cx="78%"
+            cy="8%"
+            r="28%"
+            fill={getCircleColors(timeOfDay).circle2}
+            filter="url(#blur2)"
+            opacity="0.5"
+            className="transition-all duration-1000 ease-in-out"
+          />
+
+          {/* Small yellow/accent circle */}
+          <circle
+            cx="22%"
+            cy="3%"
+            r="22%"
+            fill={getCircleColors(timeOfDay).circle3}
+            filter="url(#blur3)"
+            opacity="0.7"
+            className="transition-all duration-1000 ease-in-out"
+          />
+        </svg>
+      </div>
 
       {/* Content Container */}
       <div className="relative z-10 px-4 py-8 max-w-md mx-auto lg:max-w-6xl lg:px-8">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -177,7 +177,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
 
           {/* Name Box - positioned at bottom of image */}
           <div className="absolute bottom-0 left-0 right-0">
-            <div className="bg-white/70 backdrop-blur-md border border-black mx-[-1px] mb-[-2px] rounded-b-xl">
+            <div className="bg-white/70 border border-black mx-[-1px] mb-[-2px]" style={{ backdropFilter: 'blur(12px)', borderBottomLeftRadius: '15px', borderBottomRightRadius: '12px', borderWidth: '1.5px' }}>
               <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                 <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                   {bird.name}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -175,7 +175,7 @@ function LocationPackContent() {
         
         {/* Header Section */}
         <div className="mb-8 lg:mb-12">
-          <h1 className="text-white text-2xl lg:text-3xl font-bold leading-tight mb-2">
+          <h1 className="text-white text-2xl lg:text-3xl font-medium font-rubik uppercase leading-tight mb-2">
             {getDynamicGreeting(timeOfDay)}
           </h1>
           <p className="text-white/70 text-lg lg:text-xl font-medium">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -177,7 +177,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
 
           {/* Name Box - positioned at bottom of image */}
           <div className="absolute bottom-0 left-0 right-0">
-            <div className="bg-white/70 backdrop-blur-md border border-black mx-[-1px] mb-[-2px]">
+            <div className="bg-white/70 backdrop-blur-md border border-black mx-[-1px] mb-[-2px] rounded-b-xl">
               <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                 <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                   {bird.name}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -312,7 +312,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
           <div className="absolute bottom-0 left-0 right-0">
             <div className="bg-white/70 border-t border-black mx-[-1px] mb-[-2px]" style={{ backdropFilter: 'blur(12px)', borderBottomLeftRadius: '15px', borderBottomRightRadius: '12px', borderTopWidth: '1.5px' }}>
               <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
-                <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
+                <h3 className="text-[#2C2C2C] font-rubik font-medium text-sm uppercase leading-tight">
                   {bird.name}
                 </h3>
                 <p className="text-[#2C2C2C]/50 font-rubik text-xs italic mt-1">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -277,13 +277,15 @@ function LocationPackContent() {
       <div className="relative z-10 px-4 py-8 max-w-md mx-auto lg:max-w-6xl lg:px-8">
         
         {/* Header Section */}
-        <div className="mb-8 lg:mb-12">
-          <h1 className="text-white text-2xl lg:text-3xl font-medium font-rubik uppercase leading-tight mb-2">
-            {getDynamicGreeting(timeOfDay)}
-          </h1>
-          <p className="text-white/70 text-lg lg:text-xl font-medium">
-            {userLocation}
-          </p>
+        <div className="mb-8 lg:mb-12 mt-[300px]">
+          <div className="w-full lg:w-1/3">
+            <h1 className="text-white text-2xl lg:text-3xl font-medium font-rubik uppercase leading-tight mb-2">
+              {getDynamicGreeting(timeOfDay)}
+            </h1>
+            <p className="text-white/70 text-lg lg:text-xl font-medium">
+              {userLocation}
+            </p>
+          </div>
         </div>
 
         {/* Statistics Section */}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -165,19 +165,6 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
             </svg>
           </div>
 
-          {/* Name Box */}
-          <div className="absolute bottom-0 left-0 right-0">
-            <div className="bg-white border border-black mx-[-1px] mb-1">
-              <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
-                <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
-                  {bird.name}
-                </h3>
-                <p className="text-[#2C2C2C]/50 font-rubik text-xs italic mt-1">
-                  {bird.ability}
-                </p>
-              </div>
-            </div>
-          </div>
 
           {/* Collection indicator */}
           {isCollected && (

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -312,7 +312,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
           <div className="absolute bottom-0 left-0 right-0">
             <div className="bg-white/70 border-t border-black mx-[-1px] mb-[-2px]" style={{ backdropFilter: 'blur(12px)', borderBottomLeftRadius: '15px', borderBottomRightRadius: '12px', borderTopWidth: '1.5px' }}>
               <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
-                <h3 className="text-[#2C2C2C] font-rubik font-medium text-sm uppercase leading-tight">
+                <h3 className="text-[#2C2C2C] font-rubik font-bold text-sm uppercase leading-tight">
                   {bird.name}
                 </h3>
                 <p className="text-[#2C2C2C]/50 font-rubik text-xs italic mt-1">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -9,19 +9,52 @@ function LocationPackContent() {
   const { collectionStats, isInCollection } = useCollection();
   const [selectedBird, setSelectedBird] = useState<Bird | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
-  const [isDayTime, setIsDayTime] = useState(true);
+  const [timeOfDay, setTimeOfDay] = useState('morning');
 
-  // Function to determine if it's day time (6am-6pm)
-  const checkTimeOfDay = () => {
+  // Function to determine current time period
+  const getTimeOfDay = () => {
     const now = new Date();
     const currentHour = now.getHours();
-    return currentHour >= 6 && currentHour < 18; // 6am to 5:59pm
+
+    if (currentHour >= 5 && currentHour < 8) {
+      return 'early-morning'; // 5 AM – 8 AM
+    } else if (currentHour >= 8 && currentHour < 11) {
+      return 'morning'; // 8 AM – 11 AM
+    } else if (currentHour >= 11 && currentHour < 14) {
+      return 'noon'; // 11 AM – 2 PM
+    } else if (currentHour >= 14 && currentHour < 17) {
+      return 'afternoon'; // 2 PM – 5 PM
+    } else if (currentHour >= 17 && currentHour < 20) {
+      return 'evening'; // 5 PM – 8 PM
+    } else {
+      return 'night'; // 8 PM – 5 AM
+    }
+  };
+
+  // Function to get background gradient for each time period
+  const getBackgroundGradient = (period: string) => {
+    switch (period) {
+      case 'early-morning':
+        return 'linear-gradient(180deg, #FDF2F8 0%, #FED7AA 100%)'; // pale pink → light orange
+      case 'morning':
+        return 'linear-gradient(180deg, #FEF08A 0%, #BAE6FD 100%)'; // bright yellow → soft sky blue
+      case 'noon':
+        return 'linear-gradient(180deg, #0EA5E9 0%, #38BDF8 100%)'; // vibrant sky blue
+      case 'afternoon':
+        return 'linear-gradient(180deg, #FBBF24 0%, #FB923C 100%)'; // golden yellow → soft orange
+      case 'evening':
+        return 'linear-gradient(180deg, #EA580C 0%, #7C3AED 100%)'; // deep orange → purple
+      case 'night':
+        return 'linear-gradient(180deg, #1E293B 0%, #000000 100%)'; // dark navy → black
+      default:
+        return 'linear-gradient(180deg, #FEF08A 0%, #BAE6FD 100%)'; // fallback to morning
+    }
   };
 
   // Update background based on time of day
   useEffect(() => {
     const updateTimeOfDay = () => {
-      setIsDayTime(checkTimeOfDay());
+      setTimeOfDay(getTimeOfDay());
     };
 
     // Set initial state
@@ -50,9 +83,7 @@ function LocationPackContent() {
       <div
         className="absolute inset-0 transition-all duration-1000 ease-in-out"
         style={{
-          background: isDayTime
-            ? 'linear-gradient(180deg, #699886 52.38%, #F0F0F0 99.77%)' // Day: light teal to light gray
-            : 'linear-gradient(180deg, #4C1D95 52.38%, #1E1B4B 99.77%)' // Night: dark purple to darker purple
+          background: getBackgroundGradient(timeOfDay)
         }}
       >
       </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -31,6 +31,40 @@ function LocationPackContent() {
     }
   };
 
+  // Function to get dynamic greeting based on time period
+  const getDynamicGreeting = (period: string) => {
+    const greetings = {
+      'early-morning': [
+        "Good dawn! The Ruby-Crowned Kinglets are singing just for you.",
+        "Rise and shine! A new day of bird spotting awaits."
+      ],
+      'morning': [
+        "Chirp, chirp! Let's see what birds are up and about today.",
+        "Morning calls: time to fill your wings with adventure!"
+      ],
+      'noon': [
+        "The sun is high, and so are the Peregrine Falcons!",
+        "Time to stretch your wings and explore the skies."
+      ],
+      'afternoon': [
+        "Golden hour for golden finches.",
+        "The woods are whispering – hear the songbirds?"
+      ],
+      'evening': [
+        "Dusk is settling. The night herons are on patrol.",
+        "Evening calls: rest or spot a Steller's Jay before nightfall."
+      ],
+      'night': [
+        "Good night, little night owl. Sweet dreams of feathered friends.",
+        "The forest is quiet… perfect time to dream of tomorrow's sightings."
+      ]
+    };
+
+    const periodGreetings = greetings[period as keyof typeof greetings] || greetings.morning;
+    // Randomly select one of the two greetings for variety
+    return periodGreetings[Math.floor(Math.random() * periodGreetings.length)];
+  };
+
   // Function to get background gradient for each time period
   const getBackgroundGradient = (period: string) => {
     switch (period) {
@@ -94,11 +128,11 @@ function LocationPackContent() {
         
         {/* Header Section */}
         <div className="mb-8 lg:mb-12">
-          <h1 className="text-white text-3xl lg:text-4xl font-black uppercase tracking-wider leading-tight mb-2">
-            San Francisco
+          <h1 className="text-white text-2xl lg:text-3xl font-bold leading-tight mb-2">
+            {getDynamicGreeting(timeOfDay)}
           </h1>
           <p className="text-white/70 text-lg lg:text-xl font-medium">
-            The West
+            San Francisco, The West
           </p>
         </div>
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -277,7 +277,7 @@ function LocationPackContent() {
       <div className="relative z-10 px-4 py-8 max-w-md mx-auto lg:max-w-6xl lg:px-8">
         
         {/* Header Section */}
-        <div className="mb-8 lg:mb-12 mt-[150px]">
+        <div className="mb-8 lg:mb-12 mt-[100px]">
           <div className="w-full lg:w-1/3">
             <h1 className="text-white text-2xl lg:text-3xl font-medium font-rubik uppercase leading-tight mb-2">
               {getDynamicGreeting(timeOfDay)}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -277,7 +277,7 @@ function LocationPackContent() {
       <div className="relative z-10 px-4 py-8 max-w-md mx-auto lg:max-w-6xl lg:px-8">
         
         {/* Header Section */}
-        <div className="mb-8 lg:mb-12 mt-[300px]">
+        <div className="mb-8 lg:mb-12 mt-[150px]">
           <div className="w-full lg:w-1/3">
             <h1 className="text-white text-2xl lg:text-3xl font-medium font-rubik uppercase leading-tight mb-2">
               {getDynamicGreeting(timeOfDay)}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -168,7 +168,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
           {/* Name Box */}
           <div className="absolute bottom-0 left-0 right-0">
             <div className="bg-white border border-black mx-[-1px] mb-1">
-              <div className="px-4 py-2 text-center">
+              <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                 <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                   {bird.name}
                 </h3>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { birds, Bird } from '@shared/birds';
 import { BirdDetailModal } from '@/components/BirdDetailModal';
 import { CollectionProvider, useCollection } from '@/hooks/use-collection';
@@ -9,6 +9,29 @@ function LocationPackContent() {
   const { collectionStats, isInCollection } = useCollection();
   const [selectedBird, setSelectedBird] = useState<Bird | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
+  const [isDayTime, setIsDayTime] = useState(true);
+
+  // Function to determine if it's day time (6am-6pm)
+  const checkTimeOfDay = () => {
+    const now = new Date();
+    const currentHour = now.getHours();
+    return currentHour >= 6 && currentHour < 18; // 6am to 5:59pm
+  };
+
+  // Update background based on time of day
+  useEffect(() => {
+    const updateTimeOfDay = () => {
+      setIsDayTime(checkTimeOfDay());
+    };
+
+    // Set initial state
+    updateTimeOfDay();
+
+    // Update every minute
+    const interval = setInterval(updateTimeOfDay, 60000);
+
+    return () => clearInterval(interval);
+  }, []);
 
   // Get first 6 birds for the location pack
   const locationBirds = birds.slice(0, 6);
@@ -23,9 +46,15 @@ function LocationPackContent() {
 
   return (
     <div className="min-h-screen relative font-rubik">
-      {/* Background with gradient */}
-      <div className="absolute inset-0 bg-gradient-to-b from-[#699886] via-[#699886] to-[#F0F0F0] bg-[#F0F0F0]" 
-           style={{ background: 'linear-gradient(180deg, #699886 52.38%, #F0F0F0 99.77%)' }}>
+      {/* Dynamic Background with gradient */}
+      <div
+        className="absolute inset-0 transition-all duration-1000 ease-in-out"
+        style={{
+          background: isDayTime
+            ? 'linear-gradient(180deg, #699886 52.38%, #F0F0F0 99.77%)' // Day: light teal to light gray
+            : 'linear-gradient(180deg, #4C1D95 52.38%, #1E1B4B 99.77%)' // Night: dark purple to darker purple
+        }}
+      >
       </div>
 
       {/* Decorative illustration */}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -57,14 +57,6 @@ function LocationPackContent() {
       >
       </div>
 
-      {/* Decorative illustration */}
-      <div className="absolute top-0 right-0 w-60 h-80 lg:w-80 lg:h-96 overflow-hidden pointer-events-none">
-        <img 
-          src="https://api.builder.io/api/v1/image/assets/TEMP/55ea6c5e3b5a6de969e6a09982fc7faaefd4d165?width=480" 
-          alt="Decorative birds illustration"
-          className="w-full h-full object-cover object-left"
-        />
-      </div>
 
       {/* Content Container */}
       <div className="relative z-10 px-4 py-8 max-w-md mx-auto lg:max-w-6xl lg:px-8">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -144,7 +144,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
       {/* Card Content */}
       <div className="relative p-1 z-0">
         {/* Bird Image */}
-        <div className="relative aspect-[154/253] rounded-xl overflow-hidden border border-black">
+        <div className="relative aspect-[154/253] rounded-xl overflow-hidden border-2 border-black">
           <img 
             src={bird.imageUrl} 
             alt={bird.name}
@@ -174,19 +174,22 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
               </svg>
             </div>
           )}
-        </div>
 
-        {/* Name Box - moved to bottom of card */}
-        <div className="bg-white border border-black mx-[-1px] mb-1">
-          <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
-            <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
-              {bird.name}
-            </h3>
-            <p className="text-[#2C2C2C]/50 font-rubik text-xs italic mt-1">
-              {bird.ability}
-            </p>
+          {/* Name Box - positioned at bottom of image */}
+          <div className="absolute bottom-0 left-0 right-0">
+            <div className="bg-white border border-black mx-[-1px] mb-1">
+              <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
+                <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
+                  {bird.name}
+                </h3>
+                <p className="text-[#2C2C2C]/50 font-rubik text-xs italic mt-1">
+                  {bird.ability}
+                </p>
+              </div>
+            </div>
           </div>
         </div>
+
       </div>
     </div>
   );

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -383,10 +383,12 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
       <div className="relative p-1 z-0">
         {/* Bird Image */}
         <div className="relative aspect-[154/253] rounded-xl overflow-hidden border border-black">
-          <img 
-            src={bird.imageUrl} 
+          <img
+            src={bird.imageUrl}
             alt={bird.name}
-            className="w-full h-full object-cover"
+            className={`w-full h-full object-cover transition-all duration-300 ${
+              !isCollected ? 'grayscale' : ''
+            }`}
           />
           
           {/* Rarity Badge */}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -177,7 +177,7 @@ function LocationBirdCard({ bird, isCollected, onClick }: {
 
           {/* Name Box - positioned at bottom of image */}
           <div className="absolute bottom-0 left-0 right-0">
-            <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px] mb-1">
+            <div className="bg-white/70 backdrop-blur-sm border border-black mx-[-1px]">
               <div className="px-4 py-2 text-center flex flex-col justify-center items-center ml-0.5">
                 <h3 className="text-[#2C2C2C] font-rubik-one text-sm font-normal uppercase leading-tight">
                   {bird.name}


### PR DESCRIPTION
## Purpose

The user wanted to improve the visual consistency and layout of bird cards across the application. The main goals were to:
- Fix the dark stroke around images getting cut off at corners in the detail view
- Align the text box positioning to be flush with the bottom of the image
- Apply consistent styling between home page cards and detail view cards
- Remove the "times seen" text from the detail page for a cleaner interface

## Code changes

**BirdDetailModal.tsx:**
- Removed simulated seen count logic and display
- Updated card styling to match home page design:
  - Changed border radius from `rounded-[31px]` to `rounded-2xl`
  - Added `overflow-hidden` to prevent border cutoff
  - Simplified card structure and removed complex nested containers
  - Updated text box positioning to be flush with image bottom
  - Standardized border colors to black and improved backdrop blur
  - Adjusted rarity badge styling and positioning

**Index.tsx:**
- Updated image border from white to black for consistency
- Improved text box styling with backdrop blur effect
- Reorganized collection indicator positioning for better layout

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/83e80a331d5b432fbe0471649741aaf6/mystic-field)

👀 [Preview Link](https://83e80a331d5b432fbe0471649741aaf6-mystic-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>83e80a331d5b432fbe0471649741aaf6</projectId>-->
<!--<branchName>mystic-field</branchName>-->